### PR TITLE
Add audio uuid for quick fingerprint comparison

### DIFF
--- a/src/damn_at/analyzers/audio/acoustid_analyzer.py
+++ b/src/damn_at/analyzers/audio/acoustid_analyzer.py
@@ -2,7 +2,7 @@
 import os
 import mimetypes
 import subprocess
-
+import uuid
 from damn_at import logger
 from damn_at import AssetId, FileId, FileDescription, AssetDescription
 from damn_at.pluginmanager import IAnalyzer
@@ -58,9 +58,10 @@ class SoundAnalyzer(IAnalyzer):
 
         try:
             duration, fingerprint = fingerprint_file(anURI)
+            fingerprint_uuid = uuid.uuid5(uuid.NAMESPACE_DNS, str(duration)+fingerprint)
         except Exception as e:
             print("E: AcoustID analyzer failed %s with error %s" % (anURI, e))
-        meta = {'duration': str(duration)+'s', 'fingerprint': fingerprint}
+        meta = {'duration': str(duration)+'s', 'fingerprint': fingerprint, 'fingerprint_uuid': fingerprint_uuid}
         asset_descr.metadata = metadata.MetaDataAcoustID.extract(meta)
         file_descr.assets.append(asset_descr)
 

--- a/src/damn_at/analyzers/audio/metadata.py
+++ b/src/damn_at/analyzers/audio/metadata.py
@@ -15,4 +15,4 @@ class MetaDataAcoustID(MetaDataExtractor):
 
     duration = MetaDataType.STRING, lambda context: context['duration']
     fingerprint = MetaDataType.STRING, lambda context: context['fingerprint']
-
+    fingerprint_uuid = MetaDataType.STRING, lambda context: context['fingerprint_uuid']


### PR DESCRIPTION
Create a uuid from the SHA hash of the fingerprint and duration for quick comparisons of audio files.