### PR TITLE
fix acoustid_analyzer plugin issue

### DIFF
--- a/src/damn_at/analyzers/audio/acoustid_analyzer.py
+++ b/src/damn_at/analyzers/audio/acoustid_analyzer.py
@@ -27,7 +27,7 @@ def get_supported_formats():
         logger.debug("GetAcoustIDTypes failed! %s", oserror)
         return []
 
-    extensions = [line.split()[1] for line in out.split("\n")[4:] if len(line.split()) > 1]
+    extensions = [line.split()[1] for line in str(out).split("\n")[4:] if len(line.split()) > 1]
     mimes = []
     for ext in extensions:
         mime = mimetypes.guess_type('file.' + ext, False)[0]


### PR DESCRIPTION
before this fix, acoustid_analyzer plugin could not be able to import due to this error,

  File "/usr/lib/python3.5/site-packages/damn_at-0.0.0.dev0-py3.5.egg/damn_at/analyzers/audio/acoustid_analyzer.py", line 30, in get_supported_formats
    extensions = [line.split()[1] for line in out.split("\n")[4:] if len(line.split()) > 1]
TypeError: a bytes-like object is required, not 'str'

Detailed error trace: (http://pastebin.com/kVxbqhCb)

After fix
(http://pastebin.com/ri4ujsLi)