### PR TITLE
resolves the below commented typeError in cli.py

### DIFF
--- a/src/damn_at/cli.py
+++ b/src/damn_at/cli.py
@@ -42,7 +42,7 @@ def serialize_file_description(file_descr, format='print'):
     elif format == 'json':
         data = SerializeThriftMsg(file_descr, TSimpleJSONProtocol)
     elif format == 'json-pretty':
-        data = SerializeThriftMsg(file_descr, TSimpleJSONProtocol)
+        data = SerializeThriftMsg(file_descr, TSimpleJSONProtocol).decode()
         data = json.loads(data)
         data = json.dumps(data, indent=4)
     elif format == 'binary':


### PR DESCRIPTION
```
root@f194cb9b4f64:/sagar/peragro# pt a peragro-test-files/mesh/blender/cube1.blend -f json-pretty
Traceback (most recent call last):
  File "/usr/local/bin/pt", line 9, in <module>
    load_entry_point('damn-at==0.0.0.dev0', 'console_scripts', 'pt')()
  File "/usr/local/lib/python3.5/dist-packages/damn_at-0.0.0.dev0-py3.5.egg/damn_at/cli.py", line 353, in main
    args.func(args)
  File "/usr/local/lib/python3.5/dist-packages/damn_at-0.0.0.dev0-py3.5.egg/damn_at/cli.py", line 109, in <lambda>
    args.store
  File "/usr/local/lib/python3.5/dist-packages/damn_at-0.0.0.dev0-py3.5.egg/damn_at/cli.py", line 92, in analyze
    LOG.info(serialize_file_description(descr, format_type))
  File "/usr/local/lib/python3.5/dist-packages/damn_at-0.0.0.dev0-py3.5.egg/damn_at/cli.py", line 46, in serialize_file_description
    data = json.loads(data)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'```